### PR TITLE
Updated DocBLock to a format Eclipse IDE recognizes

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -22,7 +22,7 @@ final class Message extends Payload
     /**
      * @return bool True if the message is UTF-8 text, false if it is binary.
      *
-     * @see isBinary
+     * @see Message::isBinary()
      */
     public function isText(): bool
     {
@@ -32,7 +32,7 @@ final class Message extends Payload
     /**
      * @return bool True if the message is binary, false if it is UTF-8 text.
      *
-     * @see isText
+     * @see Message::isText()
      */
     public function isBinary(): bool
     {


### PR DESCRIPTION
[Eclipse IDE](https://www.eclipse.org/pdt/) raises Type errors for docBlock that has `@see methodName`. It does however, properly recognize `@see ObjectName::methodName()`, and features such as command+click / control+click (depending on OS) work to jump to the method the docBlock is mentioning.

**Before:**
<img width="411" alt="Screen Shot 2019-03-27 at 8 45 47 AM" src="https://user-images.githubusercontent.com/2659558/55087481-2e9f4c00-5078-11e9-87ab-624a55823963.png">

**After:**
<img width="583" alt="Screen Shot 2019-03-27 at 8 46 04 AM" src="https://user-images.githubusercontent.com/2659558/55087511-3ced6800-5078-11e9-9878-b923c51e39c4.png">

**Before (Project Tree Window Pane)**
<img width="132" alt="Screen Shot 2019-03-27 at 8 48 11 AM" src="https://user-images.githubusercontent.com/2659558/55087609-5abacd00-5078-11e9-9c3d-95aad27e7551.png">

**After**
<img width="141" alt="Screen Shot 2019-03-27 at 8 48 22 AM" src="https://user-images.githubusercontent.com/2659558/55087622-60b0ae00-5078-11e9-866d-98eb3c424b35.png">

